### PR TITLE
Fix a bug in the ARRFLoader.writeArffFile and also add an extra constructor

### DIFF
--- a/JSAT/src/jsat/ARFFLoader.java
+++ b/JSAT/src/jsat/ARFFLoader.java
@@ -196,6 +196,10 @@ public class ARFFLoader
         return dataSet;
     }
     
+    public static void writeArffFile(DataSet data, OutputStream os) {
+    	writeArffFile(data, os, "Default_Relation");
+    }
+    
     /**
      * Writes out the dataset as an ARFF file to the given stream. This method 
      * will automatically handle the target variable of 
@@ -203,10 +207,14 @@ public class ARFFLoader
      * 
      * @param data the dataset to write out
      * @param os the output stream to write too
+     * @param relation the relation label to write out
      */
-    public static void writeArffFile(DataSet data, OutputStream os)
+    public static void writeArffFile(DataSet data, OutputStream os, String relation)
     {
         PrintWriter writer = new PrintWriter(os);
+        //write out the relation tag
+        writer.write(String.format("@relation %s\n", addQuotes(relation)));
+
         //write out attributes
         //first all categorical features
         CategoricalData[] catInfo = data.getCategories();

--- a/JSAT/src/jsat/ARFFLoader.java
+++ b/JSAT/src/jsat/ARFFLoader.java
@@ -223,7 +223,7 @@ public class ARFFLoader
         if(data instanceof ClassificationDataSet)//also write out class variable
             writeCatVar(writer, ((ClassificationDataSet)data).getPredicting());
         if(data instanceof RegressionDataSet)
-            writer.write("@ATRIBUTE target NUMERIC\n");
+            writer.write("@ATTRIBUTE target NUMERIC\n");
         writer.write("@DATA\n");
         for(int row = 0; row < data.getSampleSize(); row++)
         {


### PR DESCRIPTION
When writing a RegressionDataSet the target value had a typo for "ATRIBUTE" instead of "ATTRIBUTE." Also, the output arff file was is directly loadable because it doesn't have a @relation tag set. I made the two-arg constructor spit out "@relation Default_Relation" and also added a constructor to set the relation tag. 