### PR TITLE
IndexOutOfBoundsException in PorterStemmer for single character words

### DIFF
--- a/JSAT/src/jsat/text/stemming/PorterStemmer.java
+++ b/JSAT/src/jsat/text/stemming/PorterStemmer.java
@@ -187,6 +187,8 @@ public class PorterStemmer extends Stemmer
 
         //Step 5b
         int lp = s.length()-1;
+        if(lp < 1)
+            return s;
         if(s.charAt(lp) == s.charAt(lp-1) && s.charAt(lp) == 'l')
         {
             tmp = s.substring(0, s.length() - 1);

--- a/JSAT/test/jsat/text/stemming/PorterStemmerTest.java
+++ b/JSAT/test/jsat/text/stemming/PorterStemmerTest.java
@@ -40,6 +40,7 @@ public class PorterStemmerTest
     @BeforeClass
     public static void setUpClass()
     {
+        testCases.put("a", "a");
         testCases.put("caresses", "caress");
         testCases.put("ponies", "poni");
         testCases.put("ties", "ti");


### PR DESCRIPTION
Small bugfix to the PorterStemmer implementation.

Usually short words would be filtered by an appropriate tokenizer before reaching the stemmer, but their use should not be mandatory and so it is possible to end up with single character words in the PorterStemmer. The original implementation handles this gracefully, as would JSAT's implementation with this patch.

Contribution by Catalyst.Net Ltd