### PR TITLE
Fix nested conditions

### DIFF
--- a/JSAT/src/jsat/classifiers/svm/PlattSMO.java
+++ b/JSAT/src/jsat/classifiers/svm/PlattSMO.java
@@ -333,17 +333,21 @@ public class PlattSMO extends SupportVectorLearner implements BinaryScoreClassif
                 updateSetsLabeled(i, alphas[i], C*weights.get(i));
                 
                 if(label[i] == -1)
+                {
                     if(I0[i] && (i_low == -1 || fcache[i] > fcache[i_low]) )
                     {
                         i_low = i;
                         b_low = fcache[i];
                     }
+                }
                 else
+                {
                     if(I0[i] && (i_low == -1 || fcache[i] > fcache[i_up]) )
                     {
                         i_up = i;
                         b_up = fcache[i];
                     }
+                }
             }
         }
 


### PR DESCRIPTION
Hi!
This code fragment works not the way it is formatted.

```
if(label[i] == -1)
    if(I0[i] && (i_low == -1 || fcache[i] > fcache[i_low]) )
    {
        i_low = i;
        b_low = fcache[i];
    }
else
    if(I0[i] && (i_low == -1 || fcache[i] > fcache[i_up]) )
    {
        i_up = i;
        b_up = fcache[i];
    }
```

is actually this (else sticks to the previous if):

```
if(label[i] == -1)
    if(I0[i] && (i_low == -1 || fcache[i] > fcache[i_low]) )
    {
        i_low = i;
        b_low = fcache[i];
    }
    else if(I0[i] && (i_low == -1 || fcache[i] > fcache[i_up]) )
    {
        i_up = i;
        b_up = fcache[i];
    }
```

I think this is a bug.
(I found this with the [data-flow analyzer](https://github.com/Egor18/jdataflow) I'm working on. It warns that i_low == -1 is always false in the second condition.)