### PR TITLE
Fix invalid comparison

### DIFF
--- a/JSAT/src/jsat/linear/VecOps.java
+++ b/JSAT/src/jsat/linear/VecOps.java
@@ -119,7 +119,7 @@ public class VecOps
             {
                 if(xiv.getIndex() < yiv.getIndex())
                     xiv = xIter.hasNext() ? xIter.next() : badIV;
-                else if(yiv.getIndex() > xiv.getIndex())
+                else if(xiv.getIndex() > yiv.getIndex())
                     yiv = yIter.hasNext() ? yIter.next() : badIV;
                 else//on the same page
                 {


### PR DESCRIPTION
Condition `yiv.getIndex() > xiv.getIndex()` is always false when reached here.
(I found this with the [data-flow analyzer](https://github.com/Egor18/jdataflow) I'm working on.)