### PR TITLE
Fix misprint

### DIFF
--- a/JSAT/src/jsat/regression/RegressionDataSet.java
+++ b/JSAT/src/jsat/regression/RegressionDataSet.java
@@ -165,7 +165,7 @@ public class RegressionDataSet extends DataSet<RegressionDataSet>
     {
         if(numerical.length() != numNumerVals)
             throw new RuntimeException("Data point does not contain enough numerical data points");
-        if(categories.length != categories.length)
+        if(this.categories.length != categories.length)
             throw new RuntimeException("Data point does not contain enough categorical data points");
         
         for(int i = 0; i < categories.length; i++)


### PR DESCRIPTION
Condition `categories.length != categories.length` is always false.
It should be `this.categories.length != categories.length`.
(I found this with the [data-flow analyzer](https://github.com/Egor18/jdataflow) I'm working on.)